### PR TITLE
Change table key "error" to "err"

### DIFF
--- a/LPS25H.class.nut
+++ b/LPS25H.class.nut
@@ -291,10 +291,10 @@ class LPS25H {
             }
         } catch (err) {
             if (cb == null) {
-                return {"error": err, "pressure": null};
+                return {"err": err, "pressure": null};
             } else {
                 imp.wakeup(0, function() {
-                    cb({"error": err, "pressure": null})
+                    cb({"err": err, "pressure": null})
                 });
             }
         }


### PR DESCRIPTION
This will be consistent with the README example below and other hardware libraries e.g. LIS3DH and Si702x.

``` squirrel
pressureSensor.read(function(result) {
    if ("err" in result) {
        server.error("An Error Occurred: " + result.err);
    } else {
        server.log(format("Current Pressure: %0.2f hPa", result.pressure));
    }
});
```
